### PR TITLE
Add DaemonSet for enabling/disabling kdump on COS

### DIFF
--- a/enable-kdump/cos-enable-kdump.yaml
+++ b/enable-kdump/cos-enable-kdump.yaml
@@ -1,0 +1,88 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Deploy this DaemonSet to enable kdump on the COS nodes with the
+# "cloud.google.com/gke-kdump-enabled=true" label.
+#
+# WARNING: Enabling kdump requires node reboot. Therefore, in order to avoid
+# disrupting your workloads, it is recommended to create a new node pool with
+# the "cloud.google.com/gke-kdump-enabled=true" label in your cluster,
+# deploy the DaemonSet to enable kdump in that node pool, and then migrate
+# your workloads to the new node pool.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+    name: enable-kdump
+    namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: enable-kdump
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: enable-kdump
+    spec:
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+      initContainers:
+      - name: enable-kdump
+        image: ubuntu
+        command:
+        - /bin/bash
+        - -c
+        - |
+          function verify_base_image {
+            local id="$(grep "^ID=" /host/etc/os-release)"
+            if [[ "${id#*=}" != "cos" ]]; then
+              echo "This kdump feature switch is designed to run on Container-Optimized OS only"
+              exit 0
+            fi
+          }
+          function check_kdump_feature {
+            chroot /host /usr/sbin/kdump_helper show
+          }
+          function enable_kdump_feature_and_reboot_if_needed {
+            chroot /host /usr/sbin/kdump_helper enable
+            local -r is_enabled=$(chroot /host /usr/sbin/kdump_helper show | grep "kdump enabled" | sed -rn "s/kdump enabled: (.*)/\1/p")
+            local -r is_ready=$(chroot /host /usr/sbin/kdump_helper show | grep "kdump ready" | sed -rn "s/kdump ready: (.*)/\1/p")
+            if [[ "${is_enabled}" == "true" && "${is_ready}" == "false" ]]; then 
+              echo "kdump is enabled. Rebooting for it to take effect."
+              chroot /host systemctl reboot
+            fi
+          }
+          verify_base_image
+          check_kdump_feature
+          enable_kdump_feature_and_reboot_if_needed
+        resources:
+          requests:
+            memory: 5Mi
+            cpu: 5m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host
+          mountPath: /host
+      containers:
+      - image: gcr.io/google-containers/pause:2.0
+        name: pause
+      nodeSelector:
+        "cloud.google.com/gke-kdump-enabled": "true"
+        "cloud.google.com/gke-os-distribution": "cos"


### PR DESCRIPTION
This change is to allow users to enable/disable kernel memory crash dump feature on Container-Optimized OS Kubernetes nodes. See README for more details about what it does, and how to use it.

Right now it only works with COS, and does not work with Ubuntu. Ubuntu image changes are necessary before we can enable kdump feature through a DaemonSet.

Right now the container is submitted to my development GCR repo, and is publicly shared. This is only for testing purpose.
When the code is reviewed, we can then submit it to an official GCR repo.

To test the code:
1. create a GKE cluster using 1.13+ with COS nodes, and run `kubectl apply -f cos-enable-kdump.yaml`
2. You will see the COS nodes will reboot. After the reboot finished, you can run `sudo kdump_helper show` in the node. Example:
```
gke-kdump-1-default-pool-685004bb-04m7 /home/xueweiz # kdump_helper show
kdump enabled: true
kdump ready: true
kdump kernel loaded: true
kdump kernel /boot/kdump/vmlinuz is loaded with command line parameter:
systemd.unit=kdump-save-dump.service noinitrd console=ttyS0 root=PARTUUID=81B7B545-A7DE-D64D-9355-2AB55EC1F438 maxcpus=1
```

Then this is good.