### PR TITLE
Add scripts to enable SMT

### DIFF
--- a/disable-smt/cos/enable_smt_cos.sh
+++ b/disable-smt/cos/enable_smt_cos.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xeou pipefail
+
+# Enable SMT and reboot if SMT is currently disabled.
+enable_smt() {
+  if [[ ! $(grep " nosmt " /proc/cmdline) ]]; then
+    echo "'nosmt' is not present on the kernel command line. Nothing to do."
+    return
+  fi
+  echo "Attempting to remove 'nosmt' on the kernel command line."
+  if [[ "${EUID}" -ne 0 ]]; then
+    echo "This script must be run as root."
+    return 1
+  fi
+
+  dir="$(mktemp -d)"
+  mount /dev/sda12 "${dir}"
+  sed -i -e "s| nosmt||g" "${dir}/efi/boot/grub.cfg"
+  umount "${dir}"
+  rmdir "${dir}"
+  echo "Rebooting."
+  reboot
+}
+
+enable_smt

--- a/disable-smt/gke/enable-smt.yaml
+++ b/disable-smt/gke/enable-smt.yaml
@@ -1,0 +1,98 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Deploy this DaemonSet to enable hyper-threading on the nodes with the
+# "cloud.google.com/gke-smt-disabled=false" label.
+#
+# WARNING: Enabling hyper-threading may make the node vulnerable to 
+# Microarchitectural Data Sampling (MDS). Please ensure that this is acceptable
+# before deploying this to your production clusters.
+#
+# WARNING: Enabling hyper-threading requires node reboot. Therefore, in order
+# to avoid disrupting your workloads, it is recommended to create a new node
+# pool with the "cloud.google.com/gke-smt-disabled=false" label in your cluster,
+# deploy the DaemonSet to enable hyper-threading in that node pool, and then
+# migrate your workloads to the new node pool.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: enable-smt
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: enable-smt
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: enable-smt
+    spec:
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+      initContainers:
+      - name: enable-smt
+        image: ubuntu
+        command:
+        - /bin/bash
+        - -c
+        - |
+          function enable_smt_cos {
+            local -r dir="$(mktemp -d)"
+            mount /dev/sda12 "${dir}"
+            sed -i -e "s| nosmt||g" "${dir}/efi/boot/grub.cfg"
+            umount "${dir}"
+            rmdir "${dir}"
+          }
+          function enable_smt {
+            if [[ ! $(grep " nosmt " /proc/cmdline) ]]; then
+              echo "SMT has been enabled"
+              return
+            fi
+            source /host/etc/os-release
+            echo "Attempting to enable SMT for ${NAME}"
+            case "${NAME}" in
+              "Container-Optimized OS") enable_smt_cos;;
+              *)
+                echo "${NAME} is not supported"
+                exit 1
+                ;;
+            esac
+            echo "SMT enabled, rebooting for it to take effect"
+            chroot /host systemctl reboot
+          }
+          enable_smt
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        resources:
+          requests:
+            memory: 5Mi
+            cpu: 5m
+        securityContext:
+          privileged: true
+      containers:
+      - image: gcr.io/google-containers/pause:2.0
+        name: pause
+      # Ensures that the pods will only run on the nodes having the certain
+      # label.
+      nodeSelector:
+        "cloud.google.com/gke-smt-disabled": "false"

--- a/disable-smt/gke/enable-smt.yaml
+++ b/disable-smt/gke/enable-smt.yaml
@@ -1,0 +1,102 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Deploy this DaemonSet to enable hyper-threading on the nodes with the
+# "cloud.google.com/gke-smt-disabled=false" label.
+#
+# WARNING: Enabling hyper-threading may make the node vulnerable to 
+# Microarchitectural Data Sampling (MDS). Please ensure that this is acceptable
+# before deploying this to your production clusters.
+#
+# WARNING: Enabling hyper-threading requires node reboot. Therefore, in order
+# to avoid disrupting your workloads, it is recommended to create a new node
+# pool with the "cloud.google.com/gke-smt-disabled=false" label in your cluster,
+# deploy the DaemonSet to enable hyper-threading in that node pool, and then
+# migrate your workloads to the new node pool.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: enable-smt
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: enable-smt
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: enable-smt
+    spec:
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+      initContainers:
+      - name: enable-smt
+        image: ubuntu
+        command:
+        - /bin/bash
+        - -c
+        - |
+          function enable_smt_cos {
+            local -r dir="$(mktemp -d)"
+            mount /dev/sda12 "${dir}"
+            sed -i -e "s| nosmt||g" "${dir}/efi/boot/grub.cfg"
+            umount "${dir}"
+            rmdir "${dir}"
+          }
+          function enable_smt_ubuntu {
+            rm /host/etc/default/grub.d/99-nosmt.cfg
+          }
+          function enable_smt {
+            if [[ ! $(grep " nosmt " /proc/cmdline) ]]; then
+              echo "SMT has been enabled"
+              return
+            fi
+            source /host/etc/os-release
+            echo "Attempting to enable SMT for ${NAME}"
+            case "${NAME}" in
+              "Container-Optimized OS") enable_smt_cos;;
+              "Ubuntu") enable_smt_ubuntu;;
+              *)
+                echo "${NAME} is not supported"
+                exit 1
+                ;;
+            esac
+            echo "SMT enabled, rebooting for it to take effect"
+            chroot /host systemctl reboot
+          }
+          enable_smt
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        resources:
+          requests:
+            memory: 5Mi
+            cpu: 5m
+        securityContext:
+          privileged: true
+      containers:
+      - image: gcr.io/google-containers/pause:2.0
+        name: pause
+      # Ensures that the pods will only run on the nodes having the certain
+      # label.
+      nodeSelector:
+        "cloud.google.com/gke-smt-disabled": "false"


### PR DESCRIPTION
GKE Sandbox disabled SMT by default due to MDS. These
scripts will allow users to do the reverse and enable
SMT if they decide it's acceptable for their use case.

Only do it for COS, because GKE Sandbox is not supported
in Ubuntu.