### PR TITLE
Add a deamon app to check legacy/new endpoint access counts every 5 m…

### DIFF
--- a/check-legacy-endpoint-access/check-legacy-endpoint-access.yaml
+++ b/check-legacy-endpoint-access/check-legacy-endpoint-access.yaml
@@ -1,0 +1,54 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: check-legacy-endpoint-access
+  namespace: kube-system
+  labels:
+    app: check-legacy-endpoint-access
+spec:
+  selector:
+    matchLabels:
+      app: check-legacy-endpoint-access
+  template:
+    metadata:
+      labels:
+        app: check-legacy-endpoint-access
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      hostPID: true
+      containers:
+      - name: check-legacy-endpoint-access
+        image: k8s.gcr.io/startup-script:v2
+        securityContext:
+          privileged: true
+        env:
+        - name: STARTUP_SCRIPT
+          value: |
+            #! /bin/bash
+            for ((;;))
+            do
+                date
+                echo "access count for 0.1:"
+                curl -H Metadata-Flavor:Google http://169.254.169.254/computeMetadata/v1/instance/legacy-endpoint-access/0.1
+                echo "access count for v1beta1:"
+                curl -H Metadata-Flavor:Google http://169.254.169.254/computeMetadata/v1/instance/legacy-endpoint-access/v1beta1
+                sleep 5m
+            done
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists


### PR DESCRIPTION
It returns 404 now as /computeMetadata/v1/instance/legacy-endpoint-access/0.1 and /computeMetadata/v1/instance/legacy-endpoint-access/v1beta1 hasn't been rolled out yet.