### PR TITLE
Add a deamon app to check legacy/new endpoint access counts every 5 m…

### DIFF
--- a/check-legacy-endpoint-access/README.md
+++ b/check-legacy-endpoint-access/README.md
@@ -1,0 +1,30 @@
+The check-legacy-endpoint-access tool is a Kubernates DaemonSet that checks metadata server 
+legacy access count of computeMetadata/0.1 and
+computeMetadata/v1beta1 every five minutes and writes the result to logs.
+
+## How to use it?
+Apply it to all nodes in your cluster by running the
+following command. Run the command once per cluster per
+Google Cloud Platform project.
+```
+kubectl apply -f \
+https://raw.githubusercontent.com/GoogleCloudPlatform\
+/k8s-node-tools/master/check-legacy-endpoint-access/check-legacy-endpoint-access.yaml
+```
+## How to get the result?
+Run the command below to get related log.
+```
+kubectl -n kube-system logs -l app=check-legacy-endpoint-access | grep "access
+count"
+```
+Below is a sample log entry
+```
+2019-10-17 20:35:12 for node gke-someone-k8s-default-pool-484b3c6d-csgj.c.someone-dev.internal, legacy access count of computeMetadata/0.1 is: 0, legacy access count of computeMetadata/v1beta1 is: 2
+```
+If you want to see log history, you can go to GCP console -> Logs Viewer and use
+the filter as below
+```
+resource.type="container"
+resource.labels.namespace_id="kube-system"
+logName:"/check-legacy-endpoint-access"
+```

--- a/check-legacy-endpoint-access/check-legacy-endpoint-access.yaml
+++ b/check-legacy-endpoint-access/check-legacy-endpoint-access.yaml
@@ -1,0 +1,58 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: check-legacy-endpoint-access
+  namespace: kube-system
+  labels:
+    app: check-legacy-endpoint-access
+spec:
+  selector:
+    matchLabels:
+      app: check-legacy-endpoint-access
+  template:
+    metadata:
+      labels:
+        app: check-legacy-endpoint-access
+    spec:
+      hostNetwork: true
+      containers:
+      - name: check-legacy-endpoint-access
+        image: gcr.io/distroless/python3
+        command:
+          - python
+          - -c
+          - |
+              from urllib.request import Request, urlopen
+              from datetime import datetime
+              from time import sleep
+
+              def curl(url):
+                request = Request(url)
+                request.add_header('Metadata-Flavor', 'Google')
+                response = urlopen(request).read()
+                return str(response, 'utf-8')
+
+              hostname = curl('http://169.254.169.254/computeMetadata/v1/instance/hostname')
+              while True:
+                v01_count = curl('http://169.254.169.254/computeMetadata/v1/instance/legacy-endpoint-access/0.1')
+                v1beta1_count = curl('http://169.254.169.254/computeMetadata/v1/instance/legacy-endpoint-access/v1beta1')
+                now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+                print("{} for node {}, legacy access count of computeMetadata/0.1 is: {}, legacy access count of computeMetadata/v1beta1 is: {}".format(now, hostname, v01_count, v1beta1_count), flush=True)
+
+                sleep(300)
+


### PR DESCRIPTION
Hi,
I amended the commit message, which made https://github.com/GoogleCloudPlatform/k8s-node-tools/pull/8 invalid. So I have to submit this new pull request.

* Testing
 For each node, it will print something as below every 5 minutes

```
Fri Oct 11 22:30:05 UTC 2019
access count for 0.1:
0
access count for v1beta1:
0
sleep 5 minutes
```