### PR TITLE
Use `[[` to avoid shell lint.

### DIFF
--- a/os-audit/cos-auditd-logging.yaml
+++ b/os-audit/cos-auditd-logging.yaml
@@ -82,7 +82,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [[ ! -e /var/log/fluentd-buffers ]]; then
                 exit 1;
               fi; touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck; if [[ -z "$(find /var/log/fluentd-buffers -type f -newer /tmp/marker-stuck -print -quit)" ]]; then
                 rm -rf /var/log/fluentd-buffers;


### PR DESCRIPTION
The monorepo prefers `[[` over `[` generally, as it reduces errors related to pathname expansion. Since internally, this script is standalone and imported to generate the .yaml, this avoid shell lint errors internally.