### PR TITLE
Schedule cos-auditd on gVisor nodes.

### DIFF
--- a/os-audit/cos-auditd-logging.yaml
+++ b/os-audit/cos-auditd-logging.yaml
@@ -121,6 +121,10 @@ spec:
         key: node.alpha.kubernetes.io/ismaster
       - effect: NoExecute
         operator: Exists
+      - effect: NoSchedule
+        key: sandbox.gke.io/runtime
+        operator: Equal
+        value: gvisor
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1


### PR DESCRIPTION
https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods#regular-pod describes the toleration required to schedule on a GKE Sandbox node.

Fixes #11.