### PR TITLE
Add DaemonSet to enable flag override in gVisor

### DIFF
--- a/gvisor/enable-gvisor-flags.yaml
+++ b/gvisor/enable-gvisor-flags.yaml
@@ -1,0 +1,70 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy this DaemonSet to enable flag override to gVisor pods. To set flags for
+# a given pod, add pod annotations with the following format:
+#   dev.gvisor.flag.<flag-name>: <value>
+#
+# Here is an example that enables "debug-log", "debug", and "strace" flags:
+#   metadata:
+#     annotations:
+#       dev.gvisor.flag.debug-log: "/tmp/sandbox-%ID/"
+#       dev.gvisor.flag.debug: "true"
+#       dev.gvisor.flag.strace: "true"
+#
+# Note: this is supported starting from 1.18.6-gke.3504.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: enable-gvisor-flags
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: enable-gvisor-flags
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: enable-gvisor-flags
+    spec:
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+      initContainers:
+      - name: enable-gvisor-flags
+        image: ubuntu
+        command:
+        - /bin/bash
+        - -c
+        - echo -e '  allow-flag-override = "true"' >> "/host/run/containerd/runsc/config.toml"
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        resources:
+          requests:
+            memory: 5Mi
+            cpu: 5m
+        securityContext:
+          privileged: true
+      containers:
+      - image: gcr.io/google-containers/pause:2.0
+        name: pause
+      nodeSelector:
+        "sandbox.gke.io/runtime": "gvisor"


### PR DESCRIPTION
This is useful for debugging individual pods and to test new features.