### PR TITLE
Update the stackdriver-logging-agent version.

### DIFF
--- a/os-audit/cos-auditd-logging.yaml
+++ b/os-audit/cos-auditd-logging.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:0.6-1.6.0-1
+        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:1.9.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
The current version is old and includes vulnerability issues.
That is concerning for a container that runs in priviledged mode.