### PR TITLE
Update image in config to 1.9.4

### DIFF
--- a/os-audit/cos-auditd-logging.yaml
+++ b/os-audit/cos-auditd-logging.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:0.6-1.6.0-1
+        image: gcr.io/stackdriver-agents/stackdriver-logging-agent:1.9.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
Version of stack logging agent upgraded to 1.9.4.
Version of google-fluentd = 1.13.3

Screenshot of the linux audit logs working with the new image:
![image](https://user-images.githubusercontent.com/9855990/150392284-8f16624d-7391-4405-a75f-3e2cfb0148b8.png)
