### PR TITLE
Only display project name when it contains a GKE.

### DIFF
--- a/migrating-to-containerd/find-nodepools-to-migrate.sh
+++ b/migrating-to-containerd/find-nodepools-to-migrate.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 # [START gke_node_find_non_containerd_nodepools]
-for project in  $(gcloud projects list --format="value(projectId)")
+for project in  $(gcloud projects list --format="value(projectId)" --filter="- projectId:sys-*")
 do
-  echo "ProjectId:  $project"
   for clusters in $( \
     gcloud container clusters list \
       --project $project \
       --format="csv[no-heading](name,location,autopilot.enabled,currentMasterVersion,autoscaling.enableNodeAutoprovisioning,autoscaling.autoprovisioningNodePoolDefaults.imageType)")
   do
+    printf '=%.0s' $(seq 1 $(tput cols))    
+    echo "ProjectId:  $project"
+
     IFS=',' read -r -a clustersArray <<< "$clusters"
     cluster_name="${clustersArray[0]}"
     cluster_zone="${clustersArray[1]}"

--- a/migrating-to-containerd/find-nodepools-to-migrate.sh
+++ b/migrating-to-containerd/find-nodepools-to-migrate.sh
@@ -9,6 +9,7 @@ do
       --format="csv[no-heading](name,location,autopilot.enabled,currentMasterVersion,autoscaling.enableNodeAutoprovisioning,autoscaling.autoprovisioningNodePoolDefaults.imageType)")
   do
     printf '=%.0s' $(seq 1 $(tput cols))    
+    echo ""
     echo "ProjectId:  $project"
 
     IFS=',' read -r -a clustersArray <<< "$clusters"


### PR DESCRIPTION
The result contains unneeded items :
* "gcloud projects list" return all projects you have access to, In my case it also contains projects named "sys-*" that correspond to App scripts projects (Google Sheets or  Docs, ...) Those projects won't contains a GKE.
* if a project doesn't contains a GKE, it's not needed in the result.

