### PR TITLE
Add insecure registry DaemonSet to tools

### DIFF
--- a/container-insecure-registry/insecure-registry-config.yaml
+++ b/container-insecure-registry/insecure-registry-config.yaml
@@ -26,17 +26,22 @@ spec:
           securityContext:
             privileged: true
           env:
+          - name: ADDRESS
+            value: "REGISTRY_ADDRESS"
           - name: STARTUP_SCRIPT
             value: |
               set -o errexit
               set -o pipefail
               set -o nounset
 
-              export REGISTRY_ADDRESS=ADDRESS
+              if [[ -z "$ADDRESS" || "$ADDRESS" == "REGISTRY_ADDRESS" ]]; then
+                echo "Error: Environment variable ADDRESS is not set in containers.spec.env"
+                exit 1
+              fi
 
               echo "Allowlisting insecure registries"
-              grep -qxF '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$REGISTRY_ADDRESS'"]' /etc/containerd/config.toml || \
-                echo -e '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$REGISTRY_ADDRESS'"]\n  endpoint = ["http://'$REGISTRY_ADDRESS'"]' >> /etc/containerd/config.toml
+              grep -qxF '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$ADDRESS'"]' /etc/containerd/config.toml || \
+                echo -e '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$ADDRESS'"]\n  endpoint = ["http://'$ADDRESS'"]' >> /etc/containerd/config.toml
               echo "Reloading systemd management configuration"
               systemctl daemon-reload
               echo "Restarting containerd..."

--- a/container-insecure-registry/insecure-registry-config.yaml
+++ b/container-insecure-registry/insecure-registry-config.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: insecure-registries
+  namespace: default
+  labels:
+    k8s-app: insecure-registries
+spec:
+  selector:
+    matchLabels:
+      name: insecure-registries
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: insecure-registries
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-container-runtime: "containerd"
+      hostPID: true
+      containers:
+        - name: startup-script
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              export REGISTRY_ADDRESS=ADDRESS
+
+              echo "Allowlisting insecure registries"
+              grep -qxF '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$REGISTRY_ADDRESS'"]' /etc/containerd/config.toml || \
+                echo -e '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$REGISTRY_ADDRESS'"]\n  endpoint = ["http://'$REGISTRY_ADDRESS'"]' >> /etc/containerd/config.toml
+              echo "Reloading systemd management configuration"
+              systemctl daemon-reload
+              echo "Restarting containerd..."
+              systemctl restart containerd


### PR DESCRIPTION
Adds a DaemonSet that: 

- Runs on containerd GKE nodes
- Runs a script that adds the name of an insecure registry on the local network to the containerd config on those nodes

To use this DaemonSet, replace **ADDRESS** with your insecure registry's address, like `example-registry:5000`. 