### PR TITLE
Update cos-auditd-logging.yaml example code to avoid fluent-bit bug

### DIFF
--- a/os-audit/cos-auditd-logging.yaml
+++ b/os-audit/cos-auditd-logging.yaml
@@ -181,4 +181,4 @@ data:
         k8s_cluster_location      ${CLUSTER_LOCATION}
         net.connect_timeout       60
         Retry_Limit               14
-        Workers                   2
+        Workers                   1


### PR DESCRIPTION
Setting to Workers > 1 causes intermittent crashes of the fluent-bit service. This is explained here: https://github.com/fluent/fluent-bit/issues/5081

There is no fix in place. Instead, the latest fluent-bit code defaults the Workers to 1. I was going crazy trying to figure out what was going on. I blindly used the example here and I don't want anyone else to lose time to this issue. 

I chose to set it to 1 explicitly so that this example can be compatible with older versions of fluent-bit as well.