### PR TITLE
Add kubelet log config DaemonSet to tools

### DIFF
--- a/kubelet-log-config/kubelet-log-config.yaml
+++ b/kubelet-log-config/kubelet-log-config.yaml
@@ -1,0 +1,107 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy this DaemonSet to configure kubelet log rotation on nodes with the
+# "kubelet-log-config=true" label.
+#
+# Change the values of CONTAINER_LOG_MAX_SIZE and CONTAINER_LOG_MAX_FILES to
+# suit your needs.
+#
+# WARNING: Changing the kubelet log rotation configuration requires a kubelet
+# restart. Therefore, in order to avoid disrupting your workloads, it is
+# recommended to create a new node pool with the "kubelet-log-config=true" label
+# in your cluster, deploy the DaemonSet to configure kubelet log rotation in
+# that node pool, and then migrate your workloads to the new node pool.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubelet-log-config
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: kubelet-log-config
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: kubelet-log-config
+    spec:
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+      hostPID: true
+      initContainers:
+      - name: kubelet-log-config
+        image: debian
+        env:
+        # The maximum size of the container log file before it is rotated.
+        # Update the value as desired.
+        - name: CONTAINER_LOG_MAX_SIZE
+          value: "10Mi"
+        # The maximum number of container log files that for a container.
+        # Update the value as desired.
+        - name: CONTAINER_LOG_MAX_FILES
+          value: "5"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -xeuo pipefail
+
+          # Configure the kubelet log rotation behavior.
+          # $1: Field name in kubelet configuration.
+          # $2: Value for the kubelet config field.
+          function set-kubelet-log-config() {
+            [[ "$#" -eq 2 ]] || return
+            local field; field="$1"; shift
+            local value; value="$1"; shift
+
+            local config; config="/host/home/kubernetes/kubelet-config.yaml"
+
+            echo "Remove existing configuration for ${field} if there is any."
+            sed -i "/${field}/d" "${config}"
+
+            echo "Set ${field} to ${value}."
+            echo "${field}: ${value}" >> "${config}"
+          }
+
+          set-kubelet-log-config containerLogMaxSize "${CONTAINER_LOG_MAX_SIZE}"
+          set-kubelet-log-config containerLogMaxFiles "${CONTAINER_LOG_MAX_FILES}"
+
+          echo "Restarting kubelet..."
+          chroot /host nsenter -a -t1 -- systemctl restart kubelet.service
+
+          echo "Success!"
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        resources:
+          requests:
+            memory: 5Mi
+            cpu: 5m
+        securityContext:
+          privileged: true
+      containers:
+      - image: gcr.io/google-containers/pause:3.2
+        name: pause
+      # Ensures that the pods will only run on the nodes having the correct
+      # label.
+      nodeSelector:
+        "kubelet-log-config": "true"


### PR DESCRIPTION
@SergeyKanzhelev Can you help review? Thanks!

Verified the PR manually:

1. Apply node selector label to worker nodes
2. SSH on to the worker node, check the kubelet config does not have log config
3. Apply the daemonset
4. SSH on to the worker node, check the kubelet config has the log config, and check the kubelet has just restarted from kubelet log