### PR TITLE
Skip containerd configuration if CRI config model v2 is used

### DIFF
--- a/container-insecure-registry/insecure-registry-config.yaml
+++ b/container-insecure-registry/insecure-registry-config.yaml
@@ -39,9 +39,23 @@ spec:
                 exit 1
               fi
 
-              echo "Allowlisting insecure registries"
-              grep -qxF '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$ADDRESS'"]' /etc/containerd/config.toml || \
-                echo -e '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$ADDRESS'"]\n  endpoint = ["http://'$ADDRESS'"]' >> /etc/containerd/config.toml
+              echo "Allowlisting insecure registries..."
+              containerd_config="/etc/containerd/config.toml"
+              hostpath=$(sed -nr 's;  config_path = "([-/a-z0-9_.]+)";\1;p' "$containerd_config")
+              if [[ -z "$hostpath" ]]; then
+                echo "Node uses CRI config model V1 (deprecated), adding mirror under $containerd_config..."
+                grep -qxF '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$ADDRESS'"]' "$containerd_config" || \
+                  echo -e '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."'$ADDRESS'"]\n  endpoint = ["http://'$ADDRESS'"]' >> "$containerd_config"
+              else
+                host_config_dir="$hostpath/$ADDRESS"
+                host_config_file="$host_config_dir/hosts.toml"
+                echo "Node uses CRI config model V2, adding mirror under $host_config_file..."
+                if [[ ! -e "$host_config_file" ]]; then
+                  mkdir -p "$host_config_dir"
+                  echo -e "server = \"https://$ADDRESS\"\n" > "$host_config_file"
+                fi
+                echo -e "[host.\"http://$ADDRESS\"]\n  capabilities = [\"pull\", \"resolve\"]\n" >> "$host_config_file"
+              fi
               echo "Reloading systemd management configuration"
               systemctl daemon-reload
               echo "Restarting containerd..."


### PR DESCRIPTION
## What does this PR do?
Modify `insecure-registry-config` DaemonSet to skip configuration if node uses CRI config model V2.

GKE supports ([official docs](https://cloud.google.com/kubernetes-engine/docs/how-to/access-private-registries-private-certificates)).

To validate, I used the following script:
```sh
#!/bin/bash

# Step 0: configure variables and define validation function
CLUSTER_NAME="insecure-registry-ds-test"
PROJECT_ID="YOUR-PROJECT"
ZONE="us-central1-c"
GKE_VERSION="1.29"
DAEMONSET_PATH="${GOPATH}/src/github.com/GoogleCloudPlatform/k8s-node-tools/container-insecure-registry/insecure-registry-config.yaml"
CONTAINERD_CONFIG="/tmp/containerd-config.yaml"

function validate_nodepool_daemonset() {
    local -r nodepool_name="$1"
    local -r node_name="$(kubectl get node -l="cloud.google.com/gke-nodepool=${nodepool_name}" -o name | sed "s;node/;;")"
    local -r pod_name="$(kubectl get po -l="name=insecure-registries" --field-selector="spec.nodeName=${node_name}" -o name | sed "s;pod/;;")"
    if [[ -z "${pod_name}" ]]; then
        echo "No DaemonSet pod found in node-pool ${node_name}"
    else
        echo "Logs for DaemonSet pod ${pod_name} in node-pool ${node_name}:"
        kubectl logs "${pod_name}"
    fi

    gcloud compute ssh "${node_name}" \
        --command="sudo cat /etc/containerd/config.toml" \
        --project="${PROJECT_ID}" --zone="${ZONE}"
    gcloud compute ssh "${node_name}" \
        --command="sudo cat /etc/containerd/hosts.d/my.custom.domain/hosts.toml" \
        --project="${PROJECT_ID}" --zone="${ZONE}"
}

# Step 1: create a basic 1.29 cluster
gcloud container clusters create "${CLUSTER_NAME}" \
    --num-nodes=1 --cluster-version="${GKE_VERSION}" \
    --project="${PROJECT_ID}" --zone="${ZONE}"

# Step 2: schedule DaemonSet to run in all pods
gcloud container clusters get-credentials "${CLUSTER_NAME}" \
    --project="${PROJECT_ID}" --zone="${ZONE}"
sed '0,/REGISTRY_ADDRESS/s//my.custom.domain/' "${DAEMONSET_PATH}" | kubectl apply -f -

# Step 3: create a node-pool in said cluster that uses private CA, validate
NODE_POOL_ENABLED_NAME="enabled-np"
cat <<EOF > "${CONTAINERD_CONFIG}"
privateRegistryAccessConfig:
  enabled: true
  certificateAuthorityDomainConfig:
  - gcpSecretManagerCertificateConfig:
      secretURI: "projects/1234567890/secrets/my-secret/versions/1"
    fqdns:
    - "my.custom.domain"
EOF
gcloud container node-pools create "${NODE_POOL_ENABLED_NAME}" --cluster="${CLUSTER_NAME}" \
    --num-nodes=1 --node-version="${GKE_VERSION}" \
    --containerd-config-from-file="${CONTAINERD_CONFIG}" \
    --project="${PROJECT_ID}" --zone="${ZONE}"
sleep 60
validate_nodepool_daemonset "${NODE_POOL_ENABLED_NAME}"


# Step 4: create a node-pool that doesn't use private CA, validate
NODE_POOL_DISABLED_NAME="disabled-np"
gcloud container node-pools create "${NODE_POOL_DISABLED_NAME}" --cluster="${CLUSTER_NAME}" \
    --num-nodes=1 --node-version="${GKE_VERSION}" \
    --project="${PROJECT_ID}" --zone="${ZONE}"
sleep 60
validate_nodepool_daemonset "${NODE_POOL_DISABLED_NAME}"
```