### PR TITLE
Update v1 schema pause image

### DIFF
--- a/enable-kdump/cos-enable-kdump.yaml
+++ b/enable-kdump/cos-enable-kdump.yaml
@@ -81,7 +81,7 @@ spec:
         - name: host
           mountPath: /host
       containers:
-      - image: gcr.io/google-containers/pause:2.0
+      - image: gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830
         name: pause
       nodeSelector:
         "cloud.google.com/gke-kdump-enabled": "true"

--- a/gvisor/enable-gvisor-flags.yaml
+++ b/gvisor/enable-gvisor-flags.yaml
@@ -64,7 +64,7 @@ spec:
         securityContext:
           privileged: true
       containers:
-      - image: gcr.io/google-containers/pause:2.0
+      - image: gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830
         name: pause
       nodeSelector:
         "sandbox.gke.io/runtime": "gvisor"


### PR DESCRIPTION
v1 schema images are deprecated and will no longer be supported in new container runtimes (containerd 2.0).

CC @samuelkarp @SergeyKanzhelev 