### PR TITLE
Update v1 schema startup-script image

### DIFF
--- a/container-insecure-registry/insecure-registry-config.yaml
+++ b/container-insecure-registry/insecure-registry-config.yaml
@@ -21,7 +21,7 @@ spec:
       hostPID: true
       containers:
         - name: startup-script
-          image: gcr.io/google-containers/startup-script:v1
+          image: registry.k8s.io/startup-script:v2
           imagePullPolicy: Always
           securityContext:
             privileged: true


### PR DESCRIPTION
v1 schema images are deprecated and will no longer be supported in new container runtimes (containerd 2.0).

Also included is a change to use registry.k8s.io. The legacy gcr.io/google-containers registry is deprecated.

Below is a diff of the `manage-startup-script.sh` entrypoint between these images. Included just to make sure we don't introduce any unexpected behavior changes.
```diff
diff --git a/tmp/a b/tmp/b
index e0eee3d..3e9d60c 100644
--- a/tmp/a
+++ b/tmp/b
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors.^M
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail

-CHECKPOINT_PATH="${CHECKPOINT_PATH:-/tmp/startup-script.kubernetes.io}"
+CHECKPOINT_PATH="${CHECKPOINT_PATH:-/tmp/startup-script.kubernetes.io_$(md5sum <<<"${STARTUP_SCRIPT}" | cut -c-32)}"^M
 CHECK_INTERVAL_SECONDS="30"
 EXEC=(nsenter -t 1 -m -u -i -n -p --)

@@ -25,7 +25,7 @@ do_startup_script() {
   local err=0;

   "${EXEC[@]}" bash -c "${STARTUP_SCRIPT}" && err=0 || err=$?
-  if [[ ${err} != 0 ]]; then
+  if [[ "${err}" -ne 0 ]]; then^M
     echo "!!! startup-script failed! exit code '${err}'" 1>&2
     return 1
   fi
@@ -37,7 +37,7 @@ do_startup_script() {

 while :; do
   "${EXEC[@]}" stat "${CHECKPOINT_PATH}" > /dev/null 2>&1 && err=0 || err=$?
-  if [[ ${err} != 0 ]]; then
+  if [[ "${err}" -ne 0 ]]; then^M
     do_startup_script
   fi
```

CC @SergeyKanzhelev @samuelkarp 