### PR TITLE
Add daemonset to enable containerd debug logging

### DIFF
--- a/containerd/debug-logging/README.md
+++ b/containerd/debug-logging/README.md
@@ -1,0 +1,16 @@
+# Containerd Debugging Logging
+
+The `containerd-debug-logging-daemonset.yaml` is a daemonset that enables
+containerd debug logs. These logs may be useful for troubleshooting. Note that
+debug logs are quite verbose and such increase log volume for these logs.
+
+The daemonset includes a nodeSelector targeting
+`containerd-debug-logging=true`. To run the daemonset on selected nodes for
+debugging, labels the nodes with the corresponding label (`kubectl label node
+${NODE_NAME} containerd-debug-logging=true`)
+
+Otherwise, modify the daemonset's existing
+[nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+or add an [node
+affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+to target the desired nodes or node pools.

--- a/containerd/debug-logging/containerd-debug-logging-daemonset.yaml
+++ b/containerd/debug-logging/containerd-debug-logging-daemonset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: containerd-debug-logging
+  namespace: default
+  labels:
+    k8s-app: containerd-debug-logging
+spec:
+  selector:
+    matchLabels:
+      name: containerd-debug-logging
+  template:
+    metadata:
+      labels:
+        name: containerd-debug-logging
+    spec:
+      nodeSelector:
+        containerd-debug-logging: "true"
+      hostPID: true
+      containers:
+        - name: startup-script
+          image: gke.gcr.io/startup-script:v2
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              echo "creating containerd.service.d directory"
+              mkdir -p /etc/systemd/system/containerd.service.d
+              echo "creating 10-level_debug.conf file"
+              echo -e "[Service]\nExecStart=\nExecStart=/usr/bin/containerd --log-level debug" > /etc/systemd/system/containerd.service.d/10-level_debug.conf
+              echo "Reloading systemd management configuration"
+              systemctl daemon-reload
+              echo "Restarting containerd..."
+              systemctl restart containerd


### PR DESCRIPTION
* Add `containerd-debug-logging-daemonset.yaml` which can be used to enable containerd debugging logging
* Add a README to describe the daemonset