### PR TITLE
Create containerd-nofile-infinity.yaml

### DIFF
--- a/containerd-nofile-infinity/README.md
+++ b/containerd-nofile-infinity/README.md
@@ -1,6 +1,6 @@
 # Configure Containerd NOFILE Limit
 
-This guide outlines the steps to configure the `LimitNOFILE` setting for the Containerd service on GKE nodes. This is typically used to increase the maximum number of open file descriptors allowed for containerd, which can be beneficial for high-concurrency workloads or specific applications that require a large number of open files. Since containerd 2.0 the `LimitNOFILE` has been removed - see containerd/containerd#8924 for more details.
+This guide outlines the steps to configure the `LimitNOFILE` setting for the containerd service on GKE nodes. This is typically used to increase the maximum number of open file descriptors allowed for containerd, which can be beneficial for high-concurrency workloads or specific applications that require a large number of open files. Since containerd 2.0 the `LimitNOFILE` has been removed - see containerd/containerd#8924 for more details.
 
 
 ## Instructions
@@ -12,4 +12,4 @@ This guide outlines the steps to configure the `LimitNOFILE` setting for the Con
     ```
 
 ## Note
-**This DaemonSet is specifically allowlisted for GKE Autopilot clusters.** Attempting to deploy privileged DaemonSets that modify the underlying host OS on Autopilot may lead to unexpected behavior, stability issues, or may be prevented by Autopilot's security policies. If you need to make any necessary change, please ask your Google Cloud sales representative to reach to the GKE Autopilot team.
+**This DaemonSet is specifically allowlisted for GKE Autopilot clusters.** Attempting to deploy privileged DaemonSets that modify the underlying host OS on Autopilot may lead to unexpected behavior, stability issues, or prevented by Autopilot's security policies. If you need to make any necessary change, please ask your Google Cloud sales representative to reach to the GKE Autopilot team.

--- a/containerd-nofile-infinity/README.md
+++ b/containerd-nofile-infinity/README.md
@@ -1,6 +1,7 @@
 # Configure Containerd NOFILE Limit
 
-This guide outlines the steps to configure the `LimitNOFILE` setting for the Containerd service on GKE nodes. This is typically used to increase the maximum number of open file descriptors allowed for Containerd, which can be beneficial for high-concurrency workloads or specific applications that require a large number of open files.
+This guide outlines the steps to configure the `LimitNOFILE` setting for the Containerd service on GKE nodes. This is typically used to increase the maximum number of open file descriptors allowed for containerd, which can be beneficial for high-concurrency workloads or specific applications that require a large number of open files. Since containerd 2.0 the `LimitNOFILE` has been removed - see containerd/containerd#8924 for more details.
+
 
 ## Instructions
 

--- a/containerd-nofile-infinity/README.md
+++ b/containerd-nofile-infinity/README.md
@@ -1,0 +1,14 @@
+# Configure Containerd NOFILE Limit
+
+This guide outlines the steps to configure the `LimitNOFILE` setting for the Containerd service on GKE nodes. This is typically used to increase the maximum number of open file descriptors allowed for Containerd, which can be beneficial for high-concurrency workloads or specific applications that require a large number of open files.
+
+## Instructions
+
+1.  Deploy the daemonset in `nofile-infinity-daemonset.yaml`. This DaemonSet runs a privileged container that modifies the `containerd.service` systemd unit on each node to set `LimitNOFILE=infinity` and then restarts the Containerd service.
+
+    ```bash
+    kubectl apply -f nofile-infinity-daemonset.yaml
+    ```
+
+## Note
+**This DaemonSet is specifically allowlisted for GKE Autopilot clusters.** Attempting to deploy privileged DaemonSets that modify the underlying host OS on Autopilot may lead to unexpected behavior, stability issues, or may be prevented by Autopilot's security policies. If you need to make any necessary change, please ask your Google Cloud sales representative to reach to the GKE Autopilot team.

--- a/containerd-nofile-infinity/containerd-nofile-infinity.yaml
+++ b/containerd-nofile-infinity/containerd-nofile-infinity.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nofile-infinity
+  namespace: default
+  labels:
+    k8s-app: nofile-infinity
+spec:
+  selector:
+    matchLabels:
+      name: nofile-infinity
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nofile-infinity
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-container-runtime: "containerd"
+        kubernetes.io/os: "linux"
+      hostPID: true
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+          type: DirectoryOrCreate
+      initContainers:
+        - name: startup-script
+          image: gke.gcr.io/debian-base:bookworm-v1.0.0-gke.1
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: host
+            mountPath: /host
+          command:
+          - /bin/sh
+          - -c
+          - |
+            set -e
+            set -u
+            echo "Generating containerd system drop in config for nofile limit"
+            nofile_limit_path="/host/etc/systemd/system/containerd.service.d/40-LimitNOFILE-infinity.conf"
+            cat >> "${nofile_limit_path}" <<EOF
+            [Service]
+            LimitNOFILE=infinity
+            EOF
+            echo "Reloading systemd management configuration"
+            chroot /host systemctl daemon-reload
+            echo "Restarting containerd..."
+            chroot /host systemctl restart containerd
+      containers:
+        - name: pause
+          image: gke.gcr.io/pause:3.8


### PR DESCRIPTION
Custom daemonset to re-add the nofile-infinity config removed in containerd 2.0 by https://github.com/containerd/containerd/pull/8924