### PR TITLE
Improve the resiliance of the nofile-infinity script

### DIFF
--- a/containerd-nofile-infinity/containerd-nofile-infinity-allowlist.yaml
+++ b/containerd-nofile-infinity/containerd-nofile-infinity-allowlist.yaml
@@ -4,4 +4,4 @@ metadata:
   name: gke-org-nofile-infinity-synchronizer
 spec:
   allowlistPaths:
-  - "Gke-Org/nofile-infinity/gke-org-nofile-infinity-allowlist.yaml"
+  - "Gke-Org/nofile-infinity-v2/gke-org-nofile-infinity-v2-allowlist.yaml"

--- a/containerd-nofile-infinity/containerd-nofile-infinity.yaml
+++ b/containerd-nofile-infinity/containerd-nofile-infinity.yaml
@@ -45,9 +45,13 @@ spec:
           - |
             set -e
             set -u
-            echo "Generating containerd system drop in config for nofile limit"
-            nofile_limit_path="/host/etc/systemd/system/containerd.service.d/40-LimitNOFILE-infinity.conf"
-            cat >> "${nofile_limit_path}" <<EOF
+            echo "Checking if containerd system drop-in directory exists"
+            if [ ! -d "/host/etc/systemd/system/containerd.service.d" ]; then
+              echo "containerd drop-in directory does not exist. Skipping"
+              exit 0
+            fi
+            echo "Generating containerd system drop-in config for nofile limit"
+            cat > "/host/etc/systemd/system/containerd.service.d/40-LimitNOFILE-infinity.conf" <<EOF
             [Service]
             LimitNOFILE=infinity
             EOF


### PR DESCRIPTION
This makes a few small changes to the script:
* Checks if the directory exists, and if it doesn't, just bails out.
* Overwrites any existing file on the path instead of appending.
* Doesn't use any substitutions.