### PR TITLE
AllowlistSynchronizers and misc cleanups for socket-tracer

### DIFF
--- a/containerd/socket-tracer/README.md
+++ b/containerd/socket-tracer/README.md
@@ -153,3 +153,25 @@ And to deploy the optional API reporter:
 ```sh
 $ kubectl apply -f cri-v1alpha2-api-deprecation-reporter.yaml
 ```
+
+### GKE Autopilot Users
+
+GKE Autopilot clusters enforce security policies that prevent workloads
+requiring privileged access from running by default. To deploy the
+`containerd-socket-tracer` and its companion
+`cri-v1alpha2-api-deprecation-reporter`, you must first install the
+corresponding `AllowlistSynchronizer` resources in your cluster.
+
+These synchronizers enable the workloads to run on Autopilot nodes by matching
+them with a `WorkloadAllowlist`.
+
+To install the allowlists, apply the following manifests:
+
+```sh
+$ kubectl apply -f containerd-socket-tracer-allowlist.yaml
+$ kubectl apply -f cri-v1alpha2-api-deprecation-reporter-allowlist.yaml
+```
+
+After applying these manifests and allowing a few moments for the allowlists to
+synchronize, you can deploy the `containerd-socket-tracer` and
+`cri-v1alpha2-api-deprecation-reporter` DaemonSets as described above.

--- a/containerd/socket-tracer/containerd-socket-tracer-allowlist.yaml
+++ b/containerd/socket-tracer/containerd-socket-tracer-allowlist.yaml
@@ -1,0 +1,7 @@
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: gke-org-containerd-socket-tracer-allowlist
+spec:
+  allowlistPaths:
+  - "Gke-Org/containerd-socket-tracer/gke-org-containerd-socket-tracer-allowlist.yaml"

--- a/containerd/socket-tracer/containerd-socket-tracer.yaml
+++ b/containerd/socket-tracer/containerd-socket-tracer.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         name: containerd-socket-tracer
+      annotations:
+        autopilot.gke.io/no-connect: "true"
     spec:
       hostPID: true
       containers:
@@ -78,6 +80,11 @@ spec:
               done
             done
           }
+        resources:
+          requests:
+            ephemeral-storage: "500Mi"
+          limits:
+            ephemeral-storage: "500Mi"
         env:
         - name: NODE_NAME
           valueFrom:

--- a/containerd/socket-tracer/containerd-socket-tracer.yaml
+++ b/containerd/socket-tracer/containerd-socket-tracer.yaml
@@ -91,21 +91,17 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         securityContext:
+          # Privileged is required for the bpftrace tool to use eBPF syscalls.
           privileged: true
         volumeMounts:
         - name: debugfs
           mountPath: /sys/kernel/debug
           readOnly: true
-        - name: modules
-          mountPath: /lib/modules
-          readOnly: true
       volumes:
+      # debugfs is required by bpftrace to access kernel tracepoints.
       - name: debugfs
         hostPath:
           path: /sys/kernel/debug
-      - name: modules
-        hostPath:
-          path: /lib/modules
       tolerations:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"

--- a/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter-allowlist.yaml
+++ b/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter-allowlist.yaml
@@ -1,0 +1,7 @@
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: gke-org-cri-v1alpha2-api-deprecation-reporter-allowlist
+spec:
+  allowlistPaths:
+  - "Gke-Org/containerd-socket-tracer/gke-org-cri-v1alpha2-api-deprecation-reporter-allowlist.yaml"

--- a/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter.yaml
+++ b/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         name: cri-v1alpha2-api-deprecation-reporter
+      annotations:
+        autopilot.gke.io/no-connect: "true"
     spec:
       hostPID: true
       containers:

--- a/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter.yaml
+++ b/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       hostPID: true
       containers:
-      - name: tracer
+      - name: reporter
         image: mirror.gcr.io/ubuntu
         command: ["/bin/sh", "-c"]
         args:
@@ -38,14 +38,18 @@ spec:
             fi
 
             # NOTE: You can update this interval as needed.
-            sleep 60
+            sleep $INTERVAL
           done
         env:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: INTERVAL
+          value: "60"
         securityContext:
+          # Privileged is required to use 'nsenter' to enter the host's PID
+          # namespace to run 'ctr' on the node.
           privileged: true
       tolerations:
       - key: "node.kubernetes.io/not-ready"


### PR DESCRIPTION
Enables GKE Autopilot customers to identify which workloads could be calling the CRI v1alpha2 API.

The added annotations on the workloads are necessary for matching the WorkloadAllowlist.

Also included are explicit ephemeral storage limits for the socket-tracer container. This container uses around 350MiB for installing packages, however Autopilot sets a default limit of 100MiB. When this is exceeded the Pod is evicted. Setting this to 500MiB to provide some wiggle room and allow the Pods to run on Autopilot nodes.

Also included a change to configure the sleep interval for the deprecation reporter, in case the 60 second default is too aggressive. Controlling this via an environment variable will allow Autopilot users to change this value without needing to install an updated WorkloadAllowlist.

Also included fix for the deprecation reporter name, removed an unnecessary modules volume which isn't needed by bpftrace, and some clarifying comments on why debugfs and a privileged security context are necessary.