### PR TITLE
Remove image digest for GKE Autopilot compatibility

### DIFF
--- a/containerd/socket-tracer/containerd-socket-tracer.yaml
+++ b/containerd/socket-tracer/containerd-socket-tracer.yaml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       containers:
       - name: tracer
-        image: mirror.gcr.io/ubuntu:24.04@sha256:dbdff34bb41cecdb07c79af373b44bb4c9ccba2520f014221fb95845f14bc6c1
+        image: mirror.gcr.io/ubuntu:24.04
         command: ["/bin/sh", "-c"]
         args:
         - |

--- a/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter.yaml
+++ b/containerd/socket-tracer/cri-v1alpha2-api-deprecation-reporter.yaml
@@ -19,7 +19,7 @@ spec:
       hostPID: true
       containers:
       - name: reporter
-        image: mirror.gcr.io/ubuntu:24.04@sha256:dbdff34bb41cecdb07c79af373b44bb4c9ccba2520f014221fb95845f14bc6c1
+        image: mirror.gcr.io/ubuntu:24.04
         command: ["/bin/sh", "-c"]
         args:
         - |


### PR DESCRIPTION
The WorkloadAllowlist feature in GKE Autopilot does not currently support image references that include a sha256 digest. This prevents the socket tracer and deprecation reporter workloads from being authorized to run on Autopilot clusters. Remove this digest for compatibility.