### PR TITLE
cos-disable-algif-aead: do not fail pod when SB is enabled

### DIFF
--- a/disable-algif-aead/cos-disable-algif-aead.yaml
+++ b/disable-algif-aead/cos-disable-algif-aead.yaml
@@ -70,7 +70,8 @@ spec:
             rmdir "${efi}"
             if [[ "${secure_boot}" == "True" ]]; then
               echo "Secure Boot is enabled. Boot options cannot be changed."
-              exit 1
+              sleep inf
+              exit 0
             fi
           }
 


### PR DESCRIPTION
This results in CrashLoopBackOff, which is suboptimal. Sleep instead, and exit 0 if the sleep dies.