### PR TITLE
Update mitigation guidance and tools for CVE-2026-31431

### DIFF
--- a/disable-algif-aead/README.md
+++ b/disable-algif-aead/README.md
@@ -1,6 +1,6 @@
 # DaemonSet Mitigation for CVE-2026-31431 (Copy Fail)
 
-This directory contains a privileged DaemonSet mitigation for CVE-2026-31431. It edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter. This does not change the behavior of `/etc/modprobe.d`.
+This directory contains a privileged DaemonSet mitigation for CVE-2026-31431. It edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter.
 
 ### ⚠️ Known Limitations & Caveats
 Please be aware of the following issues before deploying this DaemonSet:

--- a/disable-algif-aead/README.md
+++ b/disable-algif-aead/README.md
@@ -1,11 +1,11 @@
 # DaemonSet Mitigation for CVE-2026-31431 (Copy Fail)
 
-This directory contains a privileged DaemonSet mitigation for CVE-2026-31431. It edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter.
+This directory contains a privileged DaemonSet mitigation for CVE-2026-31431. It edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter. This does not change the behavior of `/etc/modprobe.d`.
 
 ### ⚠️ Known Limitations & Caveats
 Please be aware of the following issues before deploying this DaemonSet:
-* **Secure Boot:** This mitigation does not work if Secure Boot is enabled. The DaemonSet will enter an `Init:CrashLoopBackOff` state because Secure Boot prevents changes to the kernel command line boot options.
-* **Spot Nodes:** This mitigation is currently failing on Spot (Preemptible VM) nodes due to cgroup configuration errors during container initialization.
+* **Secure Boot:** This mitigation does not work if Secure Boot is enabled. The init container will never finish initializing because Secure Boot prevents changes to the kernel command line boot options.
+* **Spot Nodes:** We've received reports that this mitigation is currently failing on Spot (Preemptible VM) nodes due to cgroup configuration errors during container initialization, however we have been unable to reproduce this.
 * **Node Reboots:** Applying this DaemonSet will immediately reboot the affected nodes. 
 
 ## Deployment Instructions
@@ -18,9 +18,9 @@ kubectl label nodes <node-name> cloud.google.com/gke-algif-aead-disabled=true
 
 **2. Apply the DaemonSet:**
 ```bash
-kubectl apply -f daemonset.yaml
+kubectl apply -f cos-disable-algif-aead.yaml
 ```
 
 ---
 
-Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox.
+Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox, network policies and the guidance found at https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster.

--- a/disable-algif-aead/README.md
+++ b/disable-algif-aead/README.md
@@ -1,40 +1,37 @@
-# DaemonSet Mitigation for CVE-2026-31431 (Copy Fail)
+# Mitigation Advice for CVE-2026-31431 (Copy Fail)
 
-This directory contains a privileged DaemonSet mitigation for CVE-2026-31431. It edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter.
+This document provides immediate mitigation steps for CVE-2026-31431. While waiting for patched node images to roll out, you can protect your clusters using the following methods.
 
-### ⚠️ Known Limitations & Caveats
-Please be aware of the following issues before deploying this DaemonSet:
-* **Secure Boot:** This mitigation does not work if Secure Boot is enabled. The init container will never finish initializing because Secure Boot prevents changes to the kernel command line boot options.
-* **Spot Nodes:** We've received reports that this mitigation is currently failing on Spot (Preemptible VM) nodes due to cgroup configuration errors during container initialization, however we have been unable to reproduce this.
-* **Node Reboots:** Applying this DaemonSet will immediately reboot the affected nodes. 
+## GKE Standard Nodes running Container-Optimized OS (COS)
+For GKE Standard nodes running Container-Optimized OS, you can set the `initcall_blacklist=algif_aead_init` kernel parameter on your nodes to disable the impacted functionality. 
 
-## Deployment Instructions
+You can apply the privileged DaemonSet (`cos-disable-algif-aead.yaml`) provided in this directory to set this kernel parameter. Be mindful that this tool immediately reboots nodes; you can use the `cloud.google.com/gke-algif-aead-disabled` node label to control the application of the DaemonSet. This option will block legitimate usage of this kernel behavior as well as malicious usage.
 
-**1. Label your target nodes:**
-To control the rollout, label your target nodes first:
+**Deployment Instructions:**
+1. Label your target nodes to control the rollout:
 ```bash
 kubectl label nodes <node-name> cloud.google.com/gke-algif-aead-disabled=true
 ```
-
-**2. Apply the DaemonSet:**
+2. Apply the DaemonSet:
 ```bash
 kubectl apply -f cos-disable-algif-aead.yaml
 ```
 
----
+### ⚠️ Known Limitations
+* **Secure Boot:** This mitigation does not work if Secure Boot is enabled. The init container will never finish initializing because Secure Boot prevents changes to the kernel command line boot options.
+* **Spot Nodes:** We've received reports that this mitigation is intermittently failing on Spot (Preemptible VM) nodes due to cgroup configuration errors during container initialization, however we have been unable to reproduce this.
+* **Node Reboots:** Applying this DaemonSet will immediately reboot the affected nodes.
 
-Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox, network policies and the guidance found at https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster.
-
----
-
-For GKE Standard Nodes running Container-Optimized OS, you can set the `initcall_blacklist=algif_aead_init` kernel parameter on your nodes to disable the impacted functionality. You can apply this privileged DaemonSet to set this kernel parameter. Be mindful that this tool immediately reboots nodes; you can use the cloud.google.com/gke-algif-aead-disabled node label to control the application of the DaemonSet. This option will block legitimate usage of this kernel behavior as well as malicious usage.
-
-
-For GKE Standard Nodes running Ubuntu, you can blacklist the algif_aead module on your nodes (for example, by using a privileged DaemonSet) with the following commands:
+## GKE Standard Nodes running Ubuntu
+For GKE Standard nodes running Ubuntu, you can blacklist the `algif_aead` module on your nodes (for example, by using a privileged DaemonSet) with the following commands:
 
 ```bash
 echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif-aead.conf
 rmmod algif_aead 2>/dev/null
 ```
 
-GKE Autopilot does not allow running privileged daemonsets, and therefore must be mitigated by applying a custom seccomp profile to your workloads to block AF_ALG socket creation. This also works as an alternative mitigation method for GKE Standard clusters.
+## GKE Autopilot (and Alternative for Standard)
+GKE Autopilot does not allow running privileged daemonsets, and therefore must be mitigated by applying a [custom seccomp profile to your workloads to block AF_ALG socket creation](../spo-seccomp-mitigation). This also works as an alternative mitigation method for GKE Standard clusters.
+
+---
+*Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox, network policies and the guidance found at [https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster).*

--- a/disable-algif-aead/README.md
+++ b/disable-algif-aead/README.md
@@ -1,0 +1,26 @@
+# DaemonSet Mitigation for CVE-2026-31431 (Copy Fail)
+
+This directory contains a privileged DaemonSet mitigation for CVE-2026-31431. It edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter.
+
+### ⚠️ Known Limitations & Caveats
+Please be aware of the following issues before deploying this DaemonSet:
+* **Secure Boot:** This mitigation does not work if Secure Boot is enabled. The DaemonSet will enter an `Init:CrashLoopBackOff` state because Secure Boot prevents changes to the kernel command line boot options.
+* **Spot Nodes:** This mitigation is currently failing on Spot (Preemptible VM) nodes due to cgroup configuration errors during container initialization.
+* **Node Reboots:** Applying this DaemonSet will immediately reboot the affected nodes. 
+
+## Deployment Instructions
+
+**1. Label your target nodes:**
+To control the rollout, label your target nodes first:
+```bash
+kubectl label nodes <node-name> cloud.google.com/gke-algif-aead-disabled=true
+```
+
+**2. Apply the DaemonSet:**
+```bash
+kubectl apply -f daemonset.yaml
+```
+
+---
+
+Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox.

--- a/disable-algif-aead/README.md
+++ b/disable-algif-aead/README.md
@@ -24,3 +24,17 @@ kubectl apply -f cos-disable-algif-aead.yaml
 ---
 
 Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox, network policies and the guidance found at https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster.
+
+---
+
+For GKE Standard Nodes running Container-Optimized OS, you can set the `initcall_blacklist=algif_aead_init` kernel parameter on your nodes to disable the impacted functionality. You can apply this privileged DaemonSet to set this kernel parameter. Be mindful that this tool immediately reboots nodes; you can use the cloud.google.com/gke-algif-aead-disabled node label to control the application of the DaemonSet. This option will block legitimate usage of this kernel behavior as well as malicious usage.
+
+
+For GKE Standard Nodes running Ubuntu, you can blacklist the algif_aead module on your nodes (for example, by using a privileged DaemonSet) with the following commands:
+
+```bash
+echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif-aead.conf
+rmmod algif_aead 2>/dev/null
+```
+
+GKE Autopilot does not allow running privileged daemonsets, and therefore must be mitigated by applying a custom seccomp profile to your workloads to block AF_ALG socket creation. This also works as an alternative mitigation method for GKE Standard clusters.

--- a/spo-seccomp-mitigation/README.md
+++ b/spo-seccomp-mitigation/README.md
@@ -1,30 +1,62 @@
-# SPO Seccomp Mitigation for CVE-2026-31431 (Copy Fail)
+# Mitigations for CVE-2026-31431 (Copy Fail)
 
-This directory provides a mitigation for CVE-2026-31431 using the Kubernetes Security Profiles Operator (SPO). It uses a custom `SeccompProfile` that copies containerd's default allowed syscalls but blocks both `AF_VSOCK` and `AF_ALG` (socket family 38).
+This directory contains mitigation strategies for CVE-2026-31431, a Linux kernel vulnerability that allows an unprivileged local attacker to write to the system page cache, potentially leading to local privilege escalation and container escape. 
 
-## Instructions
+While waiting for patched node images to roll out, you can protect your clusters using one of the following methods.
+
+---
+
+## Method 1: Block AF_ALG via Security Profiles Operator (SPO)
+**Supported on: GKE Standard, GKE Autopilot, GDC, and Multi-Cloud**
+
+If you are using Autopilot, or if your environment cannot run privileged DaemonSets, you can block workloads from creating the `AF_ALG` sockets required for the exploit using a custom seccomp profile.
 
 **1. Install the Security Profiles Operator (SPO)**
-If you do not already have SPO installed in your cluster, follow the installation instructions here:
-[SPO Installation & Usage](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md)
+If you do not already have SPO installed, follow the [SPO Installation & Usage Guide](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md).
 
 **2. Deploy the Mitigated Seccomp Profile**
-Apply the `seccomp-profile.yaml` to create the profile in your namespace. This profile explicitly denies `AF_ALG` socket creation.
+Apply `seccomp-profile.yaml` to create the profile. This profile explicitly denies `AF_ALG` (socket family 38) and `AF_VSOCK` socket creation.
 ```bash
 kubectl apply -f seccomp-profile.yaml
 ```
 
 **3. Enable Binding on the Namespace**
-For the binding to take effect, you must label the target namespace to permit the Security Profiles Operator to modify pods within it:
+Label your target namespaces to permit SPO to modify pods within them:
 ```bash
-kubectl label ns my-namespace spo.x-k8s.io/enable-binding=true
+kubectl label ns <your-namespace> spo.x-k8s.io/enable-binding=true
 ```
 
 **4. Bind the Profile to Containers**
-Apply the `profile-binding.yaml` to bind the new seccomp profile to all containers in the namespace.
+Apply `profile-binding.yaml` to bind the new seccomp profile to all containers in the namespace.
 ```bash
 kubectl apply -f profile-binding.yaml
 ```
 
 **5. Restart Existing Pods**
-The binding is applied via a mutating webhook during pod creation. Existing pods must be restarted or recreated to pick up the new profile and be protected.
+The binding is applied via a mutating webhook during pod creation. Existing pods must be restarted or recreated to pick up the new profile.
+
+---
+
+## Method 2: Blacklist the kernel module via DaemonSet
+**Supported on: GKE Standard (with limitations)**
+
+For GKE Standard clusters, you can deploy a privileged DaemonSet that edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module and sets the `initcall_blacklist=algif_aead_init` kernel parameter. 
+
+### ⚠️ Known Limitations & Caveats
+Please be aware of the following issues before deploying this DaemonSet:
+* **Secure Boot:** This mitigation does not work if Secure Boot is enabled. The DaemonSet will enter an `Init:CrashLoopBackOff` state because Secure Boot prevents changes to the kernel command line boot options.
+* **Spot Nodes:** This mitigation is currently failing on Spot (Preemptible VM) nodes due to cgroup configuration errors during container initialization.
+* **Node Reboots:** Applying this DaemonSet will immediately reboot the affected nodes. 
+
+**Deployment:**
+To control the rollout, label your target nodes first:
+```bash
+kubectl label nodes <node-name> cloud.google.com/gke-algif-aead-disabled=true
+```
+Then, apply the DaemonSet:
+```bash
+kubectl apply -f daemonset.yaml
+```
+
+---
+*Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox.*

--- a/spo-seccomp-mitigation/README.md
+++ b/spo-seccomp-mitigation/README.md
@@ -2,6 +2,8 @@
 
 This directory provides a mitigation for CVE-2026-31431 using the Kubernetes Security Profiles Operator (SPO). It uses a custom `SeccompProfile` that copies containerd's default allowed syscalls but blocks both `AF_VSOCK` and `AF_ALG` (socket family 38).
 
+This is the recommended mitigation for GKE Autopilot clusters and environments where running privileged DaemonSets is not allowed.
+
 ## Instructions
 
 **1. Install the Security Profiles Operator (SPO)**
@@ -17,7 +19,7 @@ kubectl apply -f seccomp-profile.yaml
 **3. Enable Binding on the Namespace**
 For the binding to take effect, you must label the target namespace to permit the Security Profiles Operator to modify pods within it:
 ```bash
-kubectl label ns my-namespace spo.x-k8s.io/enable-binding=true
+kubectl label ns <your-namespace> spo.x-k8s.io/enable-binding=true
 ```
 
 **4. Bind the Profile to Containers**
@@ -28,3 +30,7 @@ kubectl apply -f profile-binding.yaml
 
 **5. Restart Existing Pods**
 The binding is applied via a mutating webhook during pod creation. Existing pods must be restarted or recreated to pick up the new profile and be protected.
+
+---
+
+_Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox._


### PR DESCRIPTION
This PR introduces immediate mitigation strategies and deployment instructions for CVE-2026-31431 (Copy Fail), a Linux kernel vulnerability that allows for container escapes and local privilege escalation via the `AF_ALG` socket family.

It updates two directories with respective mitigation methods:

1. **`spo-seccomp-mitigation/`**: Contains a custom Seccomp profile and binding to be deployed via the Security Profiles Operator (SPO). This profile blocks `AF_ALG` socket creation at the workload level and is the recommended mitigation for GKE Autopilot clusters or environments where privileged DaemonSets are prohibited.
2. **`disable-algif-aead/`**: Contains a privileged DaemonSet that edits the node's `/etc/modprobe.d` configuration to blacklist the vulnerable `algif_aead` module. The README includes important caveats regarding Secure Boot and Spot (Preemptible VM) nodes.

These mitigations are intended to protect clusters while upstream kernel patches are being absorbed and rolled out.
