### PR TITLE
cos-disable-algif-aead: increase memory request

### DIFF
--- a/disable-algif-aead/cos-disable-algif-aead.yaml
+++ b/disable-algif-aead/cos-disable-algif-aead.yaml
@@ -46,7 +46,7 @@ spec:
           privileged: true
         resources:
           requests:
-            memory: 5Mi
+            memory: 15Mi
             cpu: 5m
         volumeMounts:
         - name: host


### PR DESCRIPTION
We've seen cases of this request not being enough for runc to start a container.