### PR TITLE
Add DaemonSet mitigation for CVE-2026-43284 (Dirty Frag)

### DIFF
--- a/disable-dirty-frag/README.md
+++ b/disable-dirty-frag/README.md
@@ -1,0 +1,38 @@
+# Mitigation Advice for CVE-2026-43284 (Dirty Frag)
+
+This document provides immediate mitigation steps for CVE-2026-43284. While waiting for patched node images to roll out, you can protect your clusters using the following methods.
+
+CVE-2026-43284 is a Linux kernel privilege escalation vulnerability in ESP (Encapsulating Security Payload) in-place decryption. A second pending-assignment CVE in the same disclosure affects the RxRPC protocol (used by AFS). Local privilege escalation to root is confirmed; container escape is considered possible. Canonical rates this CVSS 3.1 7.8 (High).
+
+## GKE Standard Nodes (COS and Ubuntu)
+
+You can unload the `esp4`, `esp6`, and `rxrpc` kernel modules using the privileged DaemonSet (`disable-dirty-frag.yaml`) provided in this directory. **Unlike the algif-aead mitigation, this does not require a node reboot.** The DaemonSet re-applies the mitigation automatically on node restart.
+
+Use the `cloud.google.com/gke-dirty-frag-disabled=true` node label to control which nodes receive the mitigation.
+
+**Deployment Instructions:**
+1. Label your target nodes to control the rollout:
+```bash
+kubectl label nodes <node-name> cloud.google.com/gke-dirty-frag-disabled=true
+```
+2. Apply the DaemonSet:
+```bash
+kubectl apply -f disable-dirty-frag.yaml
+```
+
+To label all nodes at once:
+```bash
+kubectl label nodes --all cloud.google.com/gke-dirty-frag-disabled=true
+```
+
+### ⚠️ Known Limitations
+* **IPsec traffic:** Unloading `esp4` and `esp6` blocks IPsec ESP traffic. If your environment uses IPsec-based VPNs or encrypted tunnels, test thoroughly before applying.
+* **AFS clients:** The `rxrpc` module is only required by AFS clients. It is safe to disable on most GKE nodes, but verify if your workloads use the Andrew File System.
+* **Not persistent across node image replacement:** This mitigation unloads modules from the running kernel. If a node is replaced with a fresh image (e.g. after a node pool upgrade), the DaemonSet will re-apply the mitigation automatically on the replacement node, provided the node label is preserved.
+
+## GKE Autopilot (and Alternative for Standard)
+
+GKE Autopilot does not allow running privileged daemonsets, and therefore must be mitigated by applying a [custom seccomp profile to your workloads](../spo-seccomp-mitigation). This also works as an alternative mitigation method for GKE Standard clusters.
+
+---
+*Note: We do not recommend relying on containers as a strict security boundary. For stronger isolation, consider using GKE Sandbox, network policies and the guidance found at [https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster).*

--- a/disable-dirty-frag/cve-2026-43284-mitigate.sh
+++ b/disable-dirty-frag/cve-2026-43284-mitigate.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Mitigation script for CVE-2026-43284 (Dirty Frag) on GKE nodes.
+# Usage: ./cve-2026-43284-mitigate.sh [--dry-run] <project-id> <region>
+#
+# Unlike the algif-aead mitigation (CVE-2026-31431), this does NOT reboot
+# nodes and does NOT wipe the Bazel remote cache. The DaemonSet unloads the
+# esp4, esp6, and rxrpc kernel modules from each running node in-place.
+#
+# Prerequisites
+# -------------
+# 1. Install the Google Cloud CLI:
+#      https://cloud.google.com/sdk/docs/install
+#
+# 2. Install kubectl:
+#      gcloud components install kubectl
+#
+# 3. Install the GKE auth plugin (required for kubectl to authenticate to GKE):
+#      gcloud components install gke-gcloud-auth-plugin
+#
+# 4. Authenticate with an account that has access to the target GCP project.
+#    This must be a user with owner or project-level permissions — specifically:
+#      - roles/container.admin  (apply DaemonSets, label nodes, manage pods)
+#    Authenticate with:
+#      gcloud auth login
+#
+# 5. Set the active project (optional — the script accepts project-id as an argument,
+#    but setting it as default avoids prompt confusion):
+#      gcloud config set project <project-id>
+#
+# Note: If you receive a "Forbidden" error when applying the DaemonSet, your account
+# lacks container.admin on the target project. Contact the project owner to grant it.
+set -euo pipefail
+
+DRY_RUN=false
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=true
+  shift
+fi
+
+PROJECT_ID="${1:?Usage: $0 [--dry-run] <project-id> <region>}"
+REGION="${2:?Usage: $0 [--dry-run] <project-id> <region>}"
+CLUSTER_NAME="aspect-workflows"
+
+MANIFEST_URL="https://raw.githubusercontent.com/b3cramer/k8s-node-tools/master/disable-dirty-frag/disable-dirty-frag.yaml"
+
+run() {
+  if [ "$DRY_RUN" = true ]; then
+    echo "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+if [ "$DRY_RUN" = true ]; then
+  echo "==> Dry-run mode: read-only checks will run; no changes will be made."
+  echo ""
+fi
+
+# Auth always runs — it is required for read-only checks and is not destructive.
+echo "==> Authenticating to cluster $CLUSTER_NAME..."
+gcloud container clusters get-credentials "$CLUSTER_NAME" \
+  --region "$REGION" \
+  --project "$PROJECT_ID"
+
+echo "==> Checking if mitigation is already applied..."
+TOTAL=$(kubectl get pods -n kube-system 2>/dev/null | grep -c dirty-frag || true)
+RUNNING=$(kubectl get pods -n kube-system 2>/dev/null | grep dirty-frag | grep -c Running || true)
+ALREADY_APPLIED=false
+if [ "$TOTAL" -gt 0 ] && [ "$RUNNING" -eq "$TOTAL" ]; then
+  echo "    STATUS: Already applied ($RUNNING/$TOTAL nodes running) — nothing to do."
+  ALREADY_APPLIED=true
+  [ "$DRY_RUN" = true ] && echo "    No changes would be made." && exit 0
+else
+  echo "    STATUS: Not yet applied ($RUNNING/$TOTAL nodes running) — mitigation required."
+fi
+
+if [ "$ALREADY_APPLIED" = false ]; then
+
+  if [ "$DRY_RUN" = false ]; then
+    YELLOW='\033[1;33m'; RESET='\033[0m'
+    echo ""
+    echo -e "${YELLOW}  This will label all nodes and apply a privileged DaemonSet that unloads${RESET}"
+    echo -e "${YELLOW}  the esp4, esp6, and rxrpc kernel modules. No node reboots will occur${RESET}"
+    echo -e "${YELLOW}  and the Bazel remote cache will not be affected.${RESET}"
+    echo -e "${YELLOW}  Note: esp4/esp6 removal blocks IPsec ESP traffic for the node lifetime.${RESET}"
+    echo ""
+    read -r -p "  Type 'yes' to proceed: " CONFIRM
+    if [ "$CONFIRM" != "yes" ]; then
+      echo "Aborted."
+      exit 0
+    fi
+    echo ""
+  fi
+
+  echo "==> Labeling nodes to opt in to mitigation..."
+  run kubectl label nodes --all cloud.google.com/gke-dirty-frag-disabled=true --overwrite
+
+  echo "==> Applying mitigation DaemonSet..."
+  run kubectl apply -n kube-system -f "$MANIFEST_URL"
+
+  if [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo "==> Pod readiness phase (would wait for all disable-dirty-frag pods to reach Running)"
+    echo ""
+    echo "==> Dry-run complete. Re-run without --dry-run to apply."
+    exit 0
+  fi
+
+  echo "==> Waiting for mitigation pods to reach Running. This should complete in under a minute."
+  echo ""
+
+  while true; do
+    TOTAL=$(kubectl get pods -n kube-system 2>/dev/null | grep -c dirty-frag || true)
+    RUNNING=$(kubectl get pods -n kube-system 2>/dev/null | grep dirty-frag | grep -c Running || true)
+
+    echo "$(date '+%H:%M:%S')  pods: $RUNNING/$TOTAL running"
+    kubectl get pods -n kube-system 2>/dev/null | grep dirty-frag || true
+    echo ""
+
+    if [ "$TOTAL" -gt 0 ] && [ "$RUNNING" -eq "$TOTAL" ]; then
+      echo "==> All $TOTAL nodes mitigated successfully."
+      break
+    fi
+
+    sleep 5
+  done
+
+fi
+
+echo ""
+echo "==> Mitigation complete. No reboot or cache recovery required."

--- a/disable-dirty-frag/disable-dirty-frag.yaml
+++ b/disable-dirty-frag/disable-dirty-frag.yaml
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy this DaemonSet to unload the esp4, esp6, and rxrpc kernel modules
+# as an interim mitigation for CVE-2026-43284 (Dirty Frag).
+#
+# Unlike the algif-aead mitigation, this does NOT require a node reboot.
+# The init container unloads the modules from the running kernel via chroot.
+# The DaemonSet re-runs automatically on node restart, re-applying the
+# mitigation on each boot until a patched kernel image is deployed.
+#
+# NOTE: Unloading esp4 and esp6 blocks IPsec ESP traffic. If your environment
+# uses IPsec-based VPNs or encrypted tunnels, test thoroughly before applying.
+# The rxrpc module is only required by AFS clients and is safe to disable on
+# most GKE nodes.
+#
+# Use the "cloud.google.com/gke-dirty-frag-disabled=true" node label to
+# control which nodes receive this mitigation.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disable-dirty-frag
+spec:
+  selector:
+    matchLabels:
+      name: disable-dirty-frag
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: disable-dirty-frag
+    spec:
+      volumes:
+      - name: host
+        hostPath:
+          path: /
+      initContainers:
+      - name: disable-dirty-frag
+        image: marketplace.gcr.io/google/ubuntu2404
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 15Mi
+            cpu: 5m
+        volumeMounts:
+        - name: host
+          mountPath: /host
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+
+          function module_loaded() {
+            grep -qE "^${1} " /proc/modules 2>/dev/null
+          }
+
+          function main() {
+            if [[ "${EUID}" -ne 0 ]]; then
+              echo "This script must be run as root."
+              exit 1
+            fi
+
+            local changed=false
+            for mod in esp4 esp6 rxrpc; do
+              if module_loaded "${mod}"; then
+                echo "Unloading module: ${mod}"
+                if chroot /host modprobe -r "${mod}"; then
+                  changed=true
+                else
+                  echo "WARNING: could not unload ${mod} — may be in use by active IPsec/AFS sessions."
+                fi
+              else
+                echo "Module ${mod} not loaded — skipping."
+              fi
+            done
+
+            if [[ "${changed}" == "true" ]]; then
+              echo "CVE-2026-43284 (Dirty Frag) mitigation applied."
+            else
+              echo "All modules already absent. Nothing to do."
+            fi
+          }
+
+          main
+      containers:
+      - image: gke.gcr.io/pause:3.7
+        name: pause
+      nodeSelector:
+        "cloud.google.com/gke-dirty-frag-disabled": "true"
+      tolerations:
+      - key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
+        effect: NoSchedule

--- a/disable-dirty-frag/disable-dirty-frag.yaml
+++ b/disable-dirty-frag/disable-dirty-frag.yaml
@@ -109,3 +109,6 @@ spec:
         operator: Equal
         value: arm64
         effect: NoSchedule
+      - key: storage-node
+        operator: Exists
+        effect: NoSchedule


### PR DESCRIPTION
Fixes #75

## Summary

Adds `disable-dirty-frag/` with a privileged DaemonSet and README as an interim mitigation for CVE-2026-43284 (Dirty Frag), a Linux kernel privilege escalation vulnerability (CVSS 3.1 7.8 High) in ESP in-place decryption disclosed 7 May 2026.

- Unloads `esp4`, `esp6`, and `rxrpc` kernel modules via `chroot /host modprobe -r`
- **No node reboot required** — re-applies automatically on node restart via the DaemonSet lifecycle
- Works on both COS and Ubuntu GKE nodes (no EFI/GRUB manipulation needed)
- Follows the same node label pattern as the algif-aead mitigation: `cloud.google.com/gke-dirty-frag-disabled=true`

## Files

- `disable-dirty-frag/disable-dirty-frag.yaml` — DaemonSet manifest
- `disable-dirty-frag/README.md` — deployment instructions and known limitations (IPsec impact, Autopilot note)

## References

- [Ubuntu security advisory](https://ubuntu.com/security/CVE-2026-43284)
- [NVD CVE-2026-43284](https://nvd.nist.gov/vuln/detail/CVE-2026-43284)
- [Linux kernel netdev patch `f4c50a4034e6`](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4)